### PR TITLE
Fix `get_selected_entry` call

### DIFF
--- a/lua/telescope/_extensions/windows.lua
+++ b/lua/telescope/_extensions/windows.lua
@@ -1,4 +1,5 @@
 local actions = require "telescope.actions"
+local action_state = require "telescope.actions.state"
 local conf = require "telescope.config".values
 local finders = require "telescope.finders"
 local Path = require("plenary.path")
@@ -8,7 +9,7 @@ local utils = require("telescope.utils")
 local strings = require("plenary.strings")
 
 local function show_entry_window(prompt_bufnr)
-  local entry = actions.get_selected_entry(prompt_bufnr)
+  local entry = action_state.get_selected_entry()
   actions.close(prompt_bufnr)
   local winnr = entry.winnr
   vim.api.nvim_set_current_win(winnr)


### PR DESCRIPTION
It seems the location of Telescope’s `get_selected_entry` function was changed, resulting in this plugin erroring when an entry was selected. This fixes that issue. 